### PR TITLE
V2024.10.01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # Use the unifitoolbox/protect-archiver as the base image
 FROM unifitoolbox/protect-archiver:latest
 
-# Install Python and pip
+# Install Python, pip, and ffmpeg
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
+    ffmpeg \
     && apt-get clean
 
 # Set the working directory for your app


### PR DESCRIPTION
This release focuses on adding video combination functionality with the option to delete or retain original video files, improvements in environment variable handling, and updating documentation for better clarity and management.

---

### Key Changes in Version 2024.10.01

1. **Addition of `combine_videos` Method**:
    - Introduced the ability to **group and combine video files** from the same camera, sorted by timestamp.
    - The combined output file retains the name of the **first video file**, with `-combined` appended.
    - Example:
        ```
        Front Door Cam (16c2) - 2024-10-02 - 12.24.34-0500.mp4
        Front Door Cam (16c2) - 2024-10-02 - 13.00.00-0500.mp4
        ```
        Will be combined into:
        ```
        Front Door Cam (16c2) - 2024-10-02 - 12.24.34-0500 - combined.mp4
        ```

2. **New Flag `UPEM_KEEP_SPLIT_FILES`**:
    - **New environment variable** `UPEM_KEEP_SPLIT_FILES` added, allowing users to choose whether to **delete** or **keep the original split video files** after they have been successfully combined.
    - Default behavior is to **keep** the original files.
    - Set `UPEM_KEEP_SPLIT_FILES=false` to **delete the original files** after combination.
    - Handled in the `__init__` method for consistency across the application:
        ```python
        self.KEEP_SPLIT_FILES = os.getenv("UPEM_KEEP_SPLIT_FILES", "true").lower() == "true"
        ```

3. **Video Grouping by Camera Name**:
    - Videos are now grouped based on the **camera name** (extracted from the file name) and then **sorted by the timestamp** extracted from the file name.
    - This ensures that videos from the same camera are grouped and processed in the correct order.